### PR TITLE
chore: upgrade crates (env_logger, indicatif, secrecy) 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0"
 eyre = "0.6"
 clap = { version = "4.5.27", features = ["derive"] }
-env_logger = "0.9"
+env_logger = "0.11"
 log = "0.4"
 url = "2.2"
-indicatif = "0.16"
-secrecy = "0.8"
+indicatif = "0.17"
+secrecy = "0.10.3"

--- a/src/bin/spookybrew_simple.rs
+++ b/src/bin/spookybrew_simple.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use secrecy::Secret;
+use secrecy::{ExposeSecret, SecretString};
 use spookybrew_ethers_rs::handlers;
 use std::{fs, process};
 
@@ -76,7 +76,7 @@ async fn run() -> eyre::Result<()> {
     }
 }
 
-fn read_private_key(path: &str) -> eyre::Result<Secret<String>> {
+fn read_private_key(path: &str) -> eyre::Result<SecretString> {
     // Check if file exists and has proper permissions
     let metadata = fs::metadata(path)?;
 
@@ -94,14 +94,14 @@ fn read_private_key(path: &str) -> eyre::Result<Secret<String>> {
     }
 
     // Read and trim the private key
-    let private_key = fs::read_to_string(path)?.trim().to_string();
+    let private_key = SecretString::from(fs::read_to_string(path)?.trim().to_string());
 
     // Validate the private key format
-    if !validate_private_key(&private_key) {
+    if !validate_private_key(private_key.expose_secret()) {
         return Err(eyre::eyre!("Invalid private key format in file"));
     }
 
-    Ok(Secret::new(private_key))
+    Ok(private_key)
 }
 
 fn validate_private_key(key: &str) -> bool {

--- a/src/handlers/brew_boo.rs
+++ b/src/handlers/brew_boo.rs
@@ -2,11 +2,11 @@ use crate::config::Config;
 use crate::contracts::{BrewBooV2, BrewBooV3};
 use ethers::prelude::*;
 use eyre::Result;
-use secrecy::{ExposeSecret, Secret};
+use secrecy::{ExposeSecret, SecretString};
 use std::{convert::TryFrom, sync::Arc};
 
 pub async fn brew(
-    private_key: Secret<String>,
+    private_key: SecretString,
     provider_gateway: String,
     version: String,
 ) -> Result<()> {


### PR DESCRIPTION
### Changes:

- Crates upgrade:
   - env_logger 0.9 --> 0.11
   - indicatif 0.16 --> 0.17
   - secrecy 0.8 --> 0.10.3 (0.9 are skipped by the maintainer)
   
- Migrate secrecy Types `Secret<String>` --> `SecretBox<String>` alias `SecretString`