### PR TITLE
feat: separate LP pair strategy logic for contract execution in brew handlers

### DIFF
--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -12,3 +12,9 @@ abigen!(
     r"src/abi/brewboo_v3.json",
     event_derives(serde::Deserialize, serde::Serialize)
 );
+
+#[derive(Debug)]
+pub enum BrewContract<'a> {
+    V2(&'a BrewBooV2<SignerMiddleware<Provider<Http>, LocalWallet>>),
+    V3(&'a BrewBooV3<SignerMiddleware<Provider<Http>, LocalWallet>>),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
 pub mod contracts;
 pub mod handlers;
+pub mod strategies;
 // pub mod routes;

--- a/src/strategies/mod.rs
+++ b/src/strategies/mod.rs
@@ -1,5 +1,5 @@
-mod simple_strategy;
+mod simple;
 mod types;
 
-pub use simple_brew::*;
+pub use simple::*;
 pub use types::*;

--- a/src/strategies/mod.rs
+++ b/src/strategies/mod.rs
@@ -1,0 +1,5 @@
+mod simple_strategy;
+mod types;
+
+pub use simple_brew::*;
+pub use types::*;

--- a/src/strategies/simple.rs
+++ b/src/strategies/simple.rs
@@ -1,14 +1,13 @@
-use super::types::{Strategy, StrategyPair};
-use ethers::prelude::*;
+use super::types::{LiquidityPoolStrategy, Strategy};
 
 pub struct SimpleStrategy {
-    pairs: Vec<StrategyPair>,
+    pairs: Vec<LiquidityPoolStrategy>,
 }
 
 impl SimpleStrategy {
     pub fn new() -> Self {
         // Default wS/USDC.e pair
-        let pairs = vec![StrategyPair {
+        let pairs = vec![LiquidityPoolStrategy {
             token_a: "0x039e2fB66102314Ce7b64Ce5Ce3E5183bc94aD38"
                 .parse()
                 .expect("Invalid token A address"),
@@ -23,7 +22,7 @@ impl SimpleStrategy {
 }
 
 impl Strategy for SimpleStrategy {
-    fn get_pairs(&self) -> Vec<StrategyPair> {
+    fn get_pairs(&self) -> Vec<LiquidityPoolStrategy> {
         self.pairs.clone()
     }
 

--- a/src/strategies/simple_brew.rs
+++ b/src/strategies/simple_brew.rs
@@ -1,0 +1,37 @@
+use super::types::{Strategy, StrategyPair};
+use ethers::prelude::*;
+
+pub struct SimpleStrategy {
+    pairs: Vec<StrategyPair>,
+}
+
+impl SimpleStrategy {
+    pub fn new() -> Self {
+        // Default wS/USDC.e pair
+        let pairs = vec![StrategyPair {
+            token_a: "0x039e2fB66102314Ce7b64Ce5Ce3E5183bc94aD38"
+                .parse()
+                .expect("Invalid token A address"),
+            token_b: "0x29219dd400f2Bf60E5a23d13Be72B486D4038894"
+                .parse()
+                .expect("Invalid token B address"),
+            amount: None,
+        }];
+
+        Self { pairs }
+    }
+}
+
+impl Strategy for SimpleStrategy {
+    fn get_pairs(&self) -> Vec<StrategyPair> {
+        self.pairs.clone()
+    }
+
+    fn name(&self) -> &str {
+        "Simple wS/USDC.e Strategy"
+    }
+
+    fn description(&self) -> &str {
+        "A simple strategy that converts wS/USDC.e LP tokens to BOO"
+    }
+}

--- a/src/strategies/types.rs
+++ b/src/strategies/types.rs
@@ -1,0 +1,14 @@
+use ethers::prelude::*;
+
+#[derive(Debug)]
+pub struct StrategyPair {
+    pub token_a: Address,
+    pub token_b: Address,
+    pub amount: Option<U256>,
+}
+
+pub trait Strategy {
+    fn get_pairs(&self) -> Vec<StrategyPair>;
+    fn name(&self) -> &str;
+    fn description(&self) -> &str;
+}

--- a/src/strategies/types.rs
+++ b/src/strategies/types.rs
@@ -1,14 +1,14 @@
 use ethers::prelude::*;
 
-#[derive(Debug)]
-pub struct StrategyPair {
+#[derive(Debug, Clone)]
+pub struct LiquidityPoolStrategy {
     pub token_a: Address,
     pub token_b: Address,
     pub amount: Option<U256>,
 }
 
 pub trait Strategy {
-    fn get_pairs(&self) -> Vec<StrategyPair>;
+    fn get_pairs(&self) -> Vec<LiquidityPoolStrategy>;
     fn name(&self) -> &str;
     fn description(&self) -> &str;
 }


### PR DESCRIPTION
## Changes

- Added new `strategies` module for managing LP pair strategies
- Created `Strategy` trait and `LiquidityPoolStrategy` struct for strategy implementations
- Add `SimpleStrategy` with default wS/USDC.e pair
- Refactored brew handlers to use strategy pattern
- Added enum `BrewContract` to handle different contract versions safely

### Breaking Changes
- None. Existing functionality remains the same but with improved structure.

### Next
- Add more strategy implementations
- Add strategy configuration via config files